### PR TITLE
Enhancements and Fixes for Tutoring Platform

### DIFF
--- a/lib/pages/home/tutor/edit_class.dart
+++ b/lib/pages/home/tutor/edit_class.dart
@@ -80,8 +80,6 @@ class EditClass extends ConsumerWidget {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                settings: const RouteSettings(
-                                    name: "/RegisterHomePage"),
                                 builder: (context) => SearchCourseToTeach(),
                               ),
                             );
@@ -241,7 +239,6 @@ class EditClass extends ConsumerWidget {
                           _nameController.clear();
                           _descriptionController.clear();
                           Navigator.pop(context);
-
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
                               content: Row(

--- a/lib/pages/home/tutor/find_tutor.dart
+++ b/lib/pages/home/tutor/find_tutor.dart
@@ -215,8 +215,7 @@ class FindTutor extends ConsumerWidget {
                                                   height: 15,
                                                 ),
                                                 const Text("Course"),
-                                                IntrinsicWidth(
-                                                    child: Courses(groupChats)),
+                                                Courses(groupChats),
                                                 const SizedBox(
                                                   height: 10,
                                                 ),

--- a/lib/pages/home/tutor/find_tutor.dart
+++ b/lib/pages/home/tutor/find_tutor.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nylo/components/buttons/rounded_button_with_progress.dart';
 import 'package:nylo/components/no_data_holder.dart';
-import 'package:nylo/pages/home/study_group/create_study_group.dart';
+import 'package:nylo/pages/home/tutor/register_as_tutor.dart';
+import 'package:nylo/pages/home/tutor/tutor_chat_page.dart';
 import 'package:nylo/structure/models/subject_matter_model.dart';
 import 'package:nylo/structure/providers/create_group_chat_providers.dart';
 import 'package:nylo/structure/providers/direct_message_provider.dart';
@@ -66,7 +67,7 @@ class FindTutor extends ConsumerWidget {
               const Expanded(
                 child: Center(
                   child: Text(
-                    "Search study group by subject code and title",
+                    "Find tutors by subject or name",
                     textAlign: TextAlign.center,
                   ),
                 ),
@@ -80,7 +81,6 @@ class FindTutor extends ConsumerWidget {
                     );
                     return multipleGroupChatProvider.when(
                       data: (groupchats) {
-                        print("groupchats: ${groupchats.length}");
                         if (groupchats.isEmpty) {
                           return NoContent(
                               icon:
@@ -89,13 +89,13 @@ class FindTutor extends ConsumerWidget {
                                 Navigator.push(
                                   context,
                                   MaterialPageRoute(
-                                    builder: (context) => CreateStudyGroup(),
+                                    builder: (context) => RegisterAsTutorPage(),
                                   ),
                                 );
                               },
                               description:
-                                  "There is no study group available for now. Do you want to lead one?",
-                              buttonText: "Create Study Group");
+                                  "There are no classes on the aforementioned course. Do you want to lead one?",
+                              buttonText: "Create Class");
                         } else {
                           return ListView.builder(
                             itemCount: groupchats.length,
@@ -215,7 +215,8 @@ class FindTutor extends ConsumerWidget {
                                                   height: 15,
                                                 ),
                                                 const Text("Course"),
-                                                Courses(groupChats),
+                                                IntrinsicWidth(
+                                                    child: Courses(groupChats)),
                                                 const SizedBox(
                                                   height: 10,
                                                 ),
@@ -227,7 +228,7 @@ class FindTutor extends ConsumerWidget {
                                                             .notifier)
                                                         .state = true;
                                                     // create a Direct Message
-                                                    await ref
+                                                    final getData = await ref
                                                         .watch(
                                                             directMessageProvider)
                                                         .addDirectMessage(
@@ -236,11 +237,36 @@ class FindTutor extends ConsumerWidget {
                                                           groupChats.proctorId,
                                                           groupChats.classId!,
                                                         );
-                                                    Navigator.pop(context);
-                                                    ref
-                                                        .read(isLoadingProvider
-                                                            .notifier)
-                                                        .state = false;
+
+                                                    if (getData['isSuccess']) {
+                                                      Navigator.pop(context);
+
+                                                      Navigator.pushReplacement(
+                                                        context,
+                                                        MaterialPageRoute(
+                                                          builder: (context) =>
+                                                              TutorChatPage(
+                                                            groupChatId: getData[
+                                                                'directMessageId'],
+                                                            title: getData[
+                                                                'title'],
+                                                            creator: getData[
+                                                                'creator'],
+                                                            dateCreated: getData[
+                                                                'dateCreated'],
+                                                            members: getData[
+                                                                'membersId'],
+                                                            classId: getData[
+                                                                'classId'],
+                                                          ),
+                                                        ),
+                                                      );
+                                                      ref
+                                                          .read(
+                                                              isLoadingProvider
+                                                                  .notifier)
+                                                          .state = false;
+                                                    }
                                                   },
                                                   margin:
                                                       const EdgeInsets.all(0),
@@ -273,36 +299,34 @@ class FindTutor extends ConsumerWidget {
                                         10,
                                       ),
                                       child: Row(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.spaceBetween,
                                         children: [
-                                          Row(
-                                            children: [
-                                              Align(
-                                                alignment: Alignment.centerLeft,
-                                                child: ProctorImage(groupChats),
-                                              ),
-                                              const SizedBox(
-                                                width: 10,
-                                              ),
-                                              Column(
-                                                crossAxisAlignment:
-                                                    CrossAxisAlignment.start,
-                                                children: [
-                                                  Text(
-                                                    groupChats.className,
-                                                  ),
-                                                  Courses(groupChats),
-                                                ],
-                                              ),
-                                            ],
+                                          Align(
+                                              alignment: Alignment.topLeft,
+                                              child: ProctorImage(groupChats)),
+                                          Expanded(
+                                            child: Row(
+                                              children: [
+                                                const SizedBox(
+                                                  width: 10,
+                                                ),
+                                                Column(
+                                                  crossAxisAlignment:
+                                                      CrossAxisAlignment.start,
+                                                  children: [
+                                                    Text(
+                                                      groupChats.className,
+                                                    ),
+                                                    SizedBox(
+                                                      width: 250,
+                                                      child:
+                                                          Courses(groupChats),
+                                                    ),
+                                                  ],
+                                                ),
+                                              ],
+                                            ),
                                           ),
-                                          const Align(
-                                            alignment: Alignment.centerRight,
-                                            child: Icon(Icons.chevron_right),
-                                          ),
+                                          const Icon(Icons.chevron_right),
                                         ],
                                       ),
                                     ),
@@ -342,9 +366,11 @@ class FindTutor extends ConsumerWidget {
 
         return user.when(
           data: (userData) {
-            return CircleAvatar(
-              backgroundImage: NetworkImage(
-                userData.imageUrl,
+            return Container(
+              child: CircleAvatar(
+                backgroundImage: NetworkImage(
+                  userData.imageUrl,
+                ),
               ),
             );
           },

--- a/lib/pages/home/tutor/my_tutor.dart
+++ b/lib/pages/home/tutor/my_tutor.dart
@@ -100,8 +100,6 @@ class RegisterAsTutor extends ConsumerWidget {
                                     builder: (context) {
                                       return ConfirmationDialog(
                                         confirm: () async {
-                                          Navigator.pop(context);
-
                                           ScaffoldMessenger.of(context)
                                               .showSnackBar(
                                             SnackBar(

--- a/lib/pages/home/tutor/my_tutor.dart
+++ b/lib/pages/home/tutor/my_tutor.dart
@@ -36,7 +36,6 @@ class RegisterAsTutor extends ConsumerWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  settings: const RouteSettings(name: "/RegisterCategory"),
                   builder: (context) => RegisterAsTutorPage(),
                 ),
               );
@@ -183,7 +182,7 @@ class RegisterAsTutor extends ConsumerWidget {
                                             ),
                                           );
                                     }
-                                    Navigator.pop(context);
+
                                     Navigator.push(
                                       context,
                                       MaterialPageRoute(

--- a/lib/pages/home/tutor/my_tutor_classes.dart
+++ b/lib/pages/home/tutor/my_tutor_classes.dart
@@ -17,10 +17,6 @@ class TutorClassses extends ConsumerWidget {
   final FirebaseAuth _auth = FirebaseAuth.instance;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final userTutorClass =
-        ref.watch(tutorDirectMessages(_auth.currentUser!.uid));
-    final userTuteeClass =
-        ref.watch(tuteeDirectMessages(_auth.currentUser!.uid));
     final myTutor = ref.watch(myTutorProvider);
     return Scaffold(
       appBar: AppBar(

--- a/lib/pages/home/tutor/my_tutor_classes.dart
+++ b/lib/pages/home/tutor/my_tutor_classes.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:nylo/components/no_data_holder.dart';
 import 'package:nylo/pages/home/study_group/search_study_group.dart';
 import 'package:nylo/pages/home/tutor/tutor_chat_page.dart';
+import 'package:nylo/structure/models/direct_message_model.dart';
 import 'package:nylo/structure/models/subject_matter_model.dart';
 import 'package:nylo/structure/providers/direct_message_provider.dart';
 import 'package:nylo/structure/providers/register_as_tutor_providers.dart';
@@ -23,7 +24,7 @@ class TutorClassses extends ConsumerWidget {
     final myTutor = ref.watch(myTutorProvider);
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Tutors"),
+        title: const Text("Connections"),
         centerTitle: true,
       ),
       body: Column(
@@ -122,7 +123,17 @@ class TutorClassses extends ConsumerWidget {
           Expanded(
             child: Consumer(
               builder: (context, ref, child) {
-                return userTutorClass.when(
+                final AsyncValue<List<DirectMessageModel>> connections;
+
+                // Determine which function to call based on myTutor flag
+                if (myTutor) {
+                  connections =
+                      ref.watch(tutorDirectMessages(_auth.currentUser!.uid));
+                } else {
+                  connections =
+                      ref.watch(tuteeDirectMessages(_auth.currentUser!.uid));
+                }
+                return connections.when(
                   data: (ids) {
                     if (ids.isEmpty) {
                       return NoContent(
@@ -318,8 +329,6 @@ class TutorClassses extends ConsumerWidget {
                                                             children: [
                                                               Courses(
                                                                   subjectMatterInfo),
-                                                              const Text(
-                                                                  "Tutee"),
                                                               Text(
                                                                 data.name,
                                                                 style: const TextStyle(

--- a/lib/pages/home/tutor/register_as_tutor.dart
+++ b/lib/pages/home/tutor/register_as_tutor.dart
@@ -72,8 +72,6 @@ class RegisterAsTutorPage extends ConsumerWidget {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
-                                settings: const RouteSettings(
-                                    name: "/RegisterHomePage"),
                                 builder: (context) => SearchCourseToTeach(),
                               ),
                             );
@@ -129,8 +127,6 @@ class RegisterAsTutorPage extends ConsumerWidget {
                                                       selectedCoursesToTeachProvider
                                                           .notifier)
                                                   .remove(courseToRemove);
-                                              print(ref.watch(
-                                                  selectedCoursesToTeachProvider));
                                             },
                                             icon: const Icon(
                                                 Icons.remove_circle_outline),

--- a/lib/structure/providers/direct_message_provider.dart
+++ b/lib/structure/providers/direct_message_provider.dart
@@ -24,13 +24,9 @@ final tutorDirectMessages =
         .doc(institutionId)
         .collection("direct_messages")
         .where("proctorId", isNotEqualTo: userId)
-        .orderBy("proctorId",
-            descending: true) // Order by proctorId in descending order
-        .orderBy("lastMessageTimeSent",
-            descending:
-                true) // Then order by lastMessageTimeSent in descending order
-        .orderBy("__name__",
-            descending: true) // Finally order by __name__ in descending order
+        .orderBy("proctorId", descending: true)
+        .orderBy("lastMessageTimeSent", descending: true)
+        .orderBy("__name__", descending: true)
         .snapshots()
         .map(
           (querySnapshot) => querySnapshot.docs
@@ -55,13 +51,9 @@ final tuteeDirectMessages =
         .doc(institutionId)
         .collection("direct_messages")
         .where("proctorId", isEqualTo: userId)
-        .orderBy("proctorId",
-            descending: true) // Order by proctorId in descending order
-        .orderBy("lastMessageTimeSent",
-            descending:
-                true) // Then order by lastMessageTimeSent in descending order
-        .orderBy("__name__",
-            descending: true) // Finally order by __name__ in descending order
+        .orderBy("proctorId", descending: true)
+        .orderBy("lastMessageTimeSent", descending: true)
+        .orderBy("__name__", descending: true)
         .snapshots()
         .map(
           (querySnapshot) => querySnapshot.docs

--- a/lib/structure/providers/direct_message_provider.dart
+++ b/lib/structure/providers/direct_message_provider.dart
@@ -24,6 +24,13 @@ final tutorDirectMessages =
         .doc(institutionId)
         .collection("direct_messages")
         .where("proctorId", isNotEqualTo: userId)
+        .orderBy("proctorId",
+            descending: true) // Order by proctorId in descending order
+        .orderBy("lastMessageTimeSent",
+            descending:
+                true) // Then order by lastMessageTimeSent in descending order
+        .orderBy("__name__",
+            descending: true) // Finally order by __name__ in descending order
         .snapshots()
         .map(
           (querySnapshot) => querySnapshot.docs
@@ -48,6 +55,13 @@ final tuteeDirectMessages =
         .doc(institutionId)
         .collection("direct_messages")
         .where("proctorId", isEqualTo: userId)
+        .orderBy("proctorId",
+            descending: true) // Order by proctorId in descending order
+        .orderBy("lastMessageTimeSent",
+            descending:
+                true) // Then order by lastMessageTimeSent in descending order
+        .orderBy("__name__",
+            descending: true) // Finally order by __name__ in descending order
         .snapshots()
         .map(
           (querySnapshot) => querySnapshot.docs

--- a/lib/structure/providers/direct_message_provider.dart
+++ b/lib/structure/providers/direct_message_provider.dart
@@ -23,8 +23,7 @@ final tutorDirectMessages =
         .collection("institution")
         .doc(institutionId)
         .collection("direct_messages")
-        .where("proctorId", isEqualTo: userId)
-        .orderBy("__name__", descending: true)
+        .where("proctorId", isNotEqualTo: userId)
         .snapshots()
         .map(
           (querySnapshot) => querySnapshot.docs
@@ -48,8 +47,7 @@ final tuteeDirectMessages =
         .collection("institution")
         .doc(institutionId)
         .collection("direct_messages")
-        .where("proctorId", isNotEqualTo: userId)
-        .orderBy("__name__", descending: true)
+        .where("proctorId", isEqualTo: userId)
         .snapshots()
         .map(
           (querySnapshot) => querySnapshot.docs

--- a/lib/structure/services/direct_message_services.dart
+++ b/lib/structure/services/direct_message_services.dart
@@ -14,7 +14,7 @@ class DirectMessage {
   final ChatService _chatService = ChatService();
 
   // create a Direct Message
-  Future<bool> addDirectMessage(
+  Future<Map<String, dynamic>> addDirectMessage(
     String institutionId,
     String proctorId,
     String subjectMatterId,
@@ -26,7 +26,10 @@ class DirectMessage {
     final userInfodata = userInfo.data();
 
     final userName = userInfodata!['name'];
+    final proctorInfo = await _users.getUserInfo(proctorId, institutionId);
+    final proctorInfoData = proctorInfo.data();
 
+    final proctorName = proctorInfoData!['name'];
     try {
       final Timestamp timestamp = Timestamp.now();
 
@@ -138,9 +141,39 @@ class DirectMessage {
         false,
       );
 
-      return true;
+      Map<String, dynamic> createMap() {
+        Map<String, dynamic> myMap = {
+          'directMessageId': directMessageId,
+          'title': proctorName,
+          'creator': proctorId,
+          'dateCreated': timestamp.toString(),
+          'membersId': [proctorId, _auth.currentUser!.uid],
+          'classId': subjectMatterId,
+          'isSuccess': true,
+          // Add more key-value pairs as needed
+        };
+
+        return myMap;
+      }
+
+      return createMap();
     } catch (e) {
-      return false;
+      Map<String, dynamic> createMap() {
+        Map<String, dynamic> myMap = {
+          'directMessageId': '',
+          'title': '',
+          'creator': '',
+          'dateCreated': '',
+          'membersId': [],
+          'classId': '',
+          'isSuccess': false,
+          // Add more key-value pairs as needed
+        };
+
+        return myMap;
+      }
+
+      return createMap();
     }
   }
 }


### PR DESCRIPTION
- Separate tutors and tutees on the Connections page.
- Sort chats between tutors and tutees.
- Stop app from going back to Home when deleting a class.
- Direct users to chat page when they click 'Connect'.
- Correct button labels and displays.
- Fix overflow issue with courses on Find Tutors page.
- Prevent redirection to Home when updating on Edit Tutors page.
- Ensure proper sorting of tutor-tutee chats.